### PR TITLE
Fixed bad references in ReactiveTraderLinqPad.linq

### DIFF
--- a/src/ReactiveTraderLinqPad.linq
+++ b/src/ReactiveTraderLinqPad.linq
@@ -1,7 +1,6 @@
 <Query Kind="Program">
-  <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Client.Domain.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Client.Domain.dll</Reference>
+  <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Client.Domain.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Client.DomainPortable.dll</Reference>
   <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Shared.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Adaptive.ReactiveTrader.Shared.dll</Reference>
-  <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\log4net.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\log4net.dll</Reference>
   <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Microsoft.AspNet.SignalR.Client.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Microsoft.AspNet.SignalR.Client.dll</Reference>
   <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Newtonsoft.Json.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\Newtonsoft.Json.dll</Reference>
   <Reference Relative="Adaptive.ReactiveTrader.Client.Domain\bin\Debug\System.Reactive.Core.dll">&lt;MyDocuments&gt;\GitHub\ReactiveTrader\src\Adaptive.ReactiveTrader.Client.Domain\bin\Debug\System.Reactive.Core.dll</Reference>
@@ -19,21 +18,21 @@ void Main()
 {
 	var api = new ReactiveTrader();
 	api.Initialize("Trader1", new []{"http://localhost:8080"});
-	
+
 	api.ConnectionStatusStream.DumpLive("Connection");
-	
+
 	var eurusd = from currencyPairs in api.ReferenceData.GetCurrencyPairsStream()
 	             from currencyPair in currencyPairs
 				 where currencyPair.CurrencyPair.Symbol == "EURUSD"
 	             from price in currencyPair.CurrencyPair.PriceStream
 				 select price;
-				 
+
 	eurusd.Select((p,i)=> "price" + i + ":" + p.ToString()).DumpLive("EUR/USD");
-	
+
 	var targetPrice = 1.3625m;
 	var execution = from price in eurusd.Where(price=> price.Bid.Rate < targetPrice).Take(1)
 					from trade in price.Bid.ExecuteRequest(10000, "EUR")
 					select trade.ToString();
-	
-	execution.DumpLive("Execution");				 
+
+	execution.DumpLive("Execution");
 }


### PR DESCRIPTION
ReactiveTraderLinqPad.linq has two reference problems:
1) It references non-existent assembly
Adaptive.ReactiveTrader.Client.Domain.dll. The actual assembly name is
Adaptive.ReactiveTrader.Client.DomainPortable.dll.
2) It references log4net.dll, which is not being copied to
Adaptive.ReactiveTrader.Client.Domain\bin\Debug. This reference can be
safely removed.