### PR TITLE
Display Connection Type for WPF client, fixes #78

### DIFF
--- a/src/Adaptive.ReactiveTrader.Client.Domain/ConnectionInfo.cs
+++ b/src/Adaptive.ReactiveTrader.Client.Domain/ConnectionInfo.cs
@@ -6,16 +6,18 @@ namespace Adaptive.ReactiveTrader.Client.Domain
     {
         public ConnectionStatus ConnectionStatus { get; private set; }
         public string Server { get; private set; }
+        public string TransportName { get; private set; }
 
-        public ConnectionInfo(ConnectionStatus connectionStatus, string server)
+        public ConnectionInfo(ConnectionStatus connectionStatus, string server, string transportName)
         {
             ConnectionStatus = connectionStatus;
             Server = server;
+            TransportName = transportName;
         }
 
         public override string ToString()
         {
-            return string.Format("ConnectionStatus: {0}, Server: {1}", ConnectionStatus, Server);
+            return string.Format("ConnectionStatus: {0}, Server: {1}, TransportName:{2}", ConnectionStatus, Server, TransportName);
         }
     }
 }

--- a/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
+++ b/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
@@ -74,6 +74,7 @@
                         <TextBlock TextWrapping="Wrap">Server Upd.: Shows the number of price updates the UI has received from the server.</TextBlock>
                         <TextBlock TextWrapping="Wrap">CPU: Shows the CPU usage of the UI (approximately).</TextBlock>
                         <TextBlock TextWrapping="Wrap">UI Lat.: Shows the latency of the slowest price from when it was received by the UI to when it has been rendered.</TextBlock>
+                        <TextBlock TextWrapping="Wrap">ConnType: Shows the SignalR transport name initiated by the Client (webSockets, longPolling, etc).</TextBlock>
                         <TextBlock TextWrapping="Wrap"><Run>Server:</Run> <Run Text="{Binding Server}"/> </TextBlock>
                         <!--<TextBlock TextWrapping="Wrap">Histogram: Shows a more detailed breakdown of the latency distribution of rendered prices.</TextBlock>
                         <TextBlock TextWrapping="Wrap" Text="{Binding Histogram}"/>-->

--- a/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
+++ b/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
@@ -44,6 +44,9 @@
         <TextBlock ToolTipService.ShowDuration="40000">
             <Run Text="{Binding Status, Mode=OneWay}"  />
             <Run Text=" | "/>
+            <Run Text="ConnType:" />
+            <Run Text="{Binding TransportName, Mode=OneWay}"  />
+            <Run Text=" | "/>
             <Run Text="E2E Lat.:" />
             <Run Text="{Binding TotalLatency, Mode=OneWay}"  />
             <Run Text=" | "/>
@@ -62,9 +65,6 @@
             <Run Text="UI Lat.:" />
             <Run Text="{Binding UiLatency, Mode=OneWay}"  />
             <Run Text="ms"/>
-            <Run Text=" | "/>
-            <Run Text="ConnType:" />
-            <Run Text="{Binding TransportName, Mode=OneWay}"  />
             <TextBlock.ToolTip>
                 <ToolTip Width="600">
                     <StackPanel Orientation="Vertical">

--- a/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
+++ b/src/Adaptive.ReactiveTrader.Client.GUI/UI/Connectivity/ConnectivityStatusView.xaml
@@ -62,6 +62,9 @@
             <Run Text="UI Lat.:" />
             <Run Text="{Binding UiLatency, Mode=OneWay}"  />
             <Run Text="ms"/>
+            <Run Text=" | "/>
+            <Run Text="ConnType:" />
+            <Run Text="{Binding TransportName, Mode=OneWay}"  />
             <TextBlock.ToolTip>
                 <ToolTip Width="600">
                     <StackPanel Orientation="Vertical">

--- a/src/Adaptive.ReactiveTrader.Client/UI/Connectivity/ConnectivityStatusViewModel.cs
+++ b/src/Adaptive.ReactiveTrader.Client/UI/Connectivity/ConnectivityStatusViewModel.cs
@@ -86,6 +86,7 @@ namespace Adaptive.ReactiveTrader.Client.UI.Connectivity
         private void OnStatusChange(ConnectionInfo connectionInfo)
         {
             Server = connectionInfo.Server;
+            TransportName = connectionInfo.TransportName;
 
             switch (connectionInfo.ConnectionStatus)
             {
@@ -124,6 +125,7 @@ namespace Adaptive.ReactiveTrader.Client.UI.Connectivity
         public string TotalLatency { get; private set; }
         public string ServerClientLatency { get; private set; }
         public long UiLatency { get; private set; }
+        public string TransportName { get; private set; }
         public string Histogram { get; private set; }
         public string CpuTime { get; private set; }
         public string CpuPercent { get; private set; }

--- a/src/Adaptive.ReactiveTrader.Client/UI/Connectivity/IConnectivityStatusViewModel.cs
+++ b/src/Adaptive.ReactiveTrader.Client/UI/Connectivity/IConnectivityStatusViewModel.cs
@@ -10,6 +10,7 @@
         string ServerClientLatency { get; }
         string TotalLatency { get; }
         long UiLatency { get; }
+        string TransportName { get; }
         string Histogram { get; }
         string CpuTime { get; }
         string CpuPercent { get; }


### PR DESCRIPTION
Display Connection Type for WPF client (webSockets, longPolling, etc)