### PR TITLE
Fix TypeLoadException for ReactiveTrader Web after nuget upgrade

### DIFF
--- a/src/Adaptive.ReactiveTrader.Server.Domain/Adaptive.ReactiveTrader.Server.Domain.csproj
+++ b/src/Adaptive.ReactiveTrader.Server.Domain/Adaptive.ReactiveTrader.Server.Domain.csproj
@@ -93,11 +93,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reactive.Windows.Threading">
+      <HintPath>..\packages\Rx-XAML.2.2.5\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">

--- a/src/Adaptive.ReactiveTrader.Server.Domain/packages.config
+++ b/src/Adaptive.ReactiveTrader.Server.Domain/packages.config
@@ -17,4 +17,5 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
+  <package id="Rx-XAML" version="2.2.5" targetFramework="net45" />
 </packages>

--- a/src/ReactiveTrader.sln
+++ b/src/ReactiveTrader.sln
@@ -36,6 +36,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client", "Client", "{B05462
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Adaptive.ReactiveTrader.Client", "Adaptive.ReactiveTrader.Client\Adaptive.ReactiveTrader.Client.csproj", "{A894C01A-D326-40DF-BABC-0F807EB63A21}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{24D925F7-EC0E-4FD5-B71A-3DC36E072B28}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
@raybooysen This fixes the issue I saw on my machine with the Web project after the Rx nuget upgrade.