### PR TITLE
ObserveLatestOn cancels previous scheduled notification

### DIFF
--- a/src/Adaptive.ReactiveTrader.Shared/Extensions/ObservableExtensions.cs
+++ b/src/Adaptive.ReactiveTrader.Shared/Extensions/ObservableExtensions.cs
@@ -67,7 +67,7 @@ namespace Adaptive.ReactiveTrader.Shared.Extensions
             {
                 var gate = new object();
                 bool active = false;
-                var cancelable = new MultipleAssignmentDisposable();
+                var cancelable = new SerialDisposable();
                 var disposable = source.Materialize().Subscribe(thisNotification =>
                 {
                     bool wasNotAlreadyActive;
@@ -125,7 +125,7 @@ namespace Adaptive.ReactiveTrader.Shared.Extensions
                 var lastUpdateTime = DateTimeOffset.MinValue;
                 // indicate if an update is currently scheduled
                 var updateScheduled = new MultipleAssignmentDisposable();
-                // indicate if completion has been requested (we can't complete immediatly if an update is in flight)
+                // indicate if completion has been requested (we can't complete immediately if an update is in flight)
                 var completionRequested = false;
                 var gate = new object();
 


### PR DESCRIPTION
`ObserveLatestOn` should not process previous items that were scheduled if a new notification arrives. This PR corrects the usage of `MultipleAssignmentDisposable` to using the `SerialDisposable`.

This was identified at YOW when reviewing the Histogram reports, however must have forgot to submit the changes we demoed onstage.